### PR TITLE
Add CLAUDE.md and separate Frame/Axes with data normalization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,7 +163,7 @@ To test in VR: open the HTML file in a browser connected to a WebXR device (e.g.
 
 ## Roadmap (from README and code TODOs)
 
-- [ ] Separate `Frame` (position in scene) from `Axes` (scale, tick marks, labels)
+- [x] Separate `Frame` (position in scene) from `Axes` (scale, tick marks, labels)
 - [ ] Add wobble/physics to frames
 - [ ] Add color, size, and marker type parameters to scatter plots
 - [ ] Implement `Renderer` backend primitives

--- a/PlotVR/_artists.py
+++ b/PlotVR/_artists.py
@@ -17,7 +17,7 @@ from bs4 import BeautifulSoup
 
 from ._base import Artist
 
-__all__ = ['Scene', 'Frame']
+__all__ = ['Scene', 'Frame', 'Axes']
 
 class Scene(Artist):
     __html_template_fname = "_scene_template.html"
@@ -82,22 +82,67 @@ class Frame(Artist):
                                                              position="0 1 -1.5",
                                                              scale="1 1 1",
                                                              shadow='cast:false; receive:false')
-
         a_parent.append(self._a_entity)
+
+        axes = Axes(parent=self)
+        self._kids.append(axes)
+        self._current_axes = axes
+
+    def gca(self):
+        return self._current_axes
+
+
+class Axes(Artist):
+    def __init__(self, parent):
+        super(Axes, self).__init__(parent)
+        self._a_entity = self._parent.get_a_entity()  # reuse Frame's entity; no new wrapper
+
         self._a_entity.append(self.soup.new_tag("a-entity", id='framebounds',
                                                 geometry="primitive: box",
                                                 position="0.5 0.5 0.5",
                                                 material="color: blue; side:back; transparent:true; opacity:0.2; flatShading: true",
                                                 shadow='cast:false; receive:false',
-                                                mixin='frame_mix'
-                                                ))
+                                                mixin='frame_mix'))
 
         self._a_entity.append(self.soup.new_tag("a-entity", id='axes',
                                                 line__0="start: 0, 0, 0; end: 1 0 0; color: red",
                                                 line__1="start: 0, 0, 0; end: 0 1 0; color: green",
                                                 line__2="start: 0, 0, 0; end: 0 0 1; color: blue",
-                                                shadow='cast:false; receive:false'
-                                               ))
+                                                shadow='cast:false; receive:false'))
+
+        self._raw_data = []  # list of (x, y, z, color) tuples
+
+    def register_data(self, x, y, z, color):
+        self._raw_data.append((x, y, z, color))
+
+    def show(self):
+        if self._raw_data:
+            import numpy as np
+
+            def _bounds(idx):
+                arrays = [d[idx] for d in self._raw_data]
+                return min(a.min() for a in arrays), max(a.max() for a in arrays)
+
+            def _norm(arr, lo, hi):
+                if hi == lo:
+                    return np.full_like(arr, 0.5, dtype=float)
+                return (arr - lo) / (hi - lo)
+
+            x_min, x_max = _bounds(0)
+            y_min, y_max = _bounds(1)
+            z_min, z_max = _bounds(2)
+
+            for x, y, z, color in self._raw_data:
+                ms = MarkerSet(parent=self,
+                               x=_norm(x, x_min, x_max),
+                               y=_norm(y, y_min, y_max),
+                               z=_norm(z, z_min, z_max),
+                               color=color)
+                self._kids.append(ms)
+
+            self._raw_data = []  # prevent double-render if show() called again
+
+        super(Axes, self).show()
 
 
 class MarkerSet(Artist):

--- a/PlotVR/_plotvr.py
+++ b/PlotVR/_plotvr.py
@@ -12,7 +12,7 @@ data will be plotted relative to these axes.
 
 * https://github.com/andreasplesch/aframe-meshline-component
 
-TODO: add distinction between frame and axes
+DONE: added distinction between frame and axes (see _artists.py)
 TODO: add axes graphics and interaction
 TODO: add wobble to frames
 TODO: add color, size, and marker to scatterplot
@@ -21,7 +21,7 @@ TODO: add color, size, and marker to scatterplot
 
 __all__ = ['scene', 'plot', 'show']
 
-from ._artists import Scene, MarkerSet
+from ._artists import Scene
 
 __all_scenes = {}
 __current_scene = None
@@ -51,8 +51,8 @@ def plot(x, y, z, color="#FFFFFF"):
 
     if __current_scene is None:
         scene()
-    frame = __current_scene.gcf()
-    frame.add_artist(MarkerSet(parent=frame, x=x, y=y, z=z, color=color))
+    axes = __current_scene.gcf().gca()
+    axes.register_data(x, y, z, color)
 
 def show():
     global __current_scene, __all_scenes


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` with comprehensive codebase documentation (architecture, API, conventions, roadmap)
- Separate `Frame` (spatial container) from new `Axes` class (data bounds + axis visualization)
- Add data normalization in `Axes.show()` — all datasets are scaled to [0,1] at render time, fixing a bug where arbitrary-range data would overflow the frame box

## Changes

- `PlotVR/_artists.py`: `Frame` slimmed to pure transform container; new `Axes` class owns `#framebounds`, `#axes` entities and normalization logic; `Frame.gca()` added mirroring matplotlib
- `PlotVR/_plotvr.py`: `plot()` now calls `axes.register_data()` instead of constructing `MarkerSet` directly
- `CLAUDE.md`: new file documenting the full codebase