### PR TITLE
Implement VR controller Event handling (closes #7)

### DIFF
--- a/PlotVR/_artists.py
+++ b/PlotVR/_artists.py
@@ -109,10 +109,10 @@ class Axes(Artist):
                                                 line__2="start: 0, 0, 0; end: 0 0 1; color: blue",
                                                 shadow='cast:false; receive:false'))
 
-        self._raw_data = []  # list of (x, y, z, color, size, marker) tuples
+        self._raw_data = []  # list of (x, y, z, color, size, marker, event) tuples
 
-    def register_data(self, x, y, z, color, size, marker):
-        self._raw_data.append((x, y, z, color, size, marker))
+    def register_data(self, x, y, z, color, size, marker, event=None):
+        self._raw_data.append((x, y, z, color, size, marker, event))
 
     def show(self):
         if self._raw_data:
@@ -131,14 +131,15 @@ class Axes(Artist):
             y_min, y_max = _bounds(1)
             z_min, z_max = _bounds(2)
 
-            for x, y, z, color, size, marker in self._raw_data:
+            for x, y, z, color, size, marker, event in self._raw_data:
                 ms = MarkerSet(parent=self,
                                x=_norm(x, x_min, x_max),
                                y=_norm(y, y_min, y_max),
                                z=_norm(z, z_min, z_max),
                                color=color,
                                size=size,
-                               marker=marker)
+                               marker=marker,
+                               event=event)
                 self._kids.append(ms)
 
             self._raw_data = []  # prevent double-render if show() called again
@@ -158,7 +159,8 @@ _MARKER_TAGS = {
 }
 
 class MarkerSet(Artist):
-    def __init__(self, parent, x, y, z, color="#EF2D5E", size=0.01, marker='sphere'):
+    def __init__(self, parent, x, y, z, color="#EF2D5E", size=0.01, marker='sphere',
+                 event=None):
         import numpy as np
 
         super(MarkerSet, self).__init__(parent)
@@ -172,10 +174,27 @@ class MarkerSet(Artist):
         colors = [color] * n if isinstance(color, str) else list(color)
         sizes  = [size]  * n if np.isscalar(size)  else list(size)
 
-        for px, py, pz, pc, ps in zip(x, y, z, colors, sizes):
-            self._a_entity.append(self.soup.new_tag(tag,
-                                                    position=f'{px} {py} {pz}',
-                                                    radius=str(ps),
-                                                    color=pc,
-                                                    shadow='cast:true; receive:false'
-                                                    ))
+        # Resolve annotation texts once so we can index per-point below.
+        if event is not None and event._annotation is not None:
+            ann_texts, _, _ = event._annotation
+            if isinstance(ann_texts, str):
+                ann_texts = [ann_texts] * n
+            else:
+                ann_texts = list(ann_texts)
+        else:
+            ann_texts = None
+
+        event_attrs = event.to_aframe_attrs() if event is not None else {}
+
+        for i, (px, py, pz, pc, ps) in enumerate(zip(x, y, z, colors, sizes)):
+            marker_tag = self.soup.new_tag(tag,
+                                           position=f'{px} {py} {pz}',
+                                           radius=str(ps),
+                                           color=pc,
+                                           shadow='cast:true; receive:false',
+                                           **event_attrs)
+            if ann_texts is not None:
+                label = event.make_annotation_tag(self.soup, ann_texts[i])
+                if label is not None:
+                    marker_tag.append(label)
+            self._a_entity.append(marker_tag)

--- a/PlotVR/_base.py
+++ b/PlotVR/_base.py
@@ -42,7 +42,139 @@ class Renderer():
 
 class Event():
     """
-    Event handlers for VR controllers
+    Event handlers for VR controllers.
+
+    Maps A-Frame controller events (hover, grip, trigger) to attribute changes
+    and text annotations on data-point markers.  Because PlotVR generates static
+    HTML, handlers are translated to A-Frame ``event-set__`` attributes and
+    ``<a-text>`` child elements at render time.
+
+    Usage example::
+
+        import PlotVR as pvr
+        import numpy as np
+
+        pos = np.random.rand(20, 3)
+        ev = pvr.Event()
+        ev.on(pvr.Event.HOVER_START, 'material.color', '#FFFF00')
+        ev.on(pvr.Event.HOVER_END,   'material.color', '#EF2D5E')
+        ev.annotate([f'point {i}' for i in range(20)])
+        pvr.scatter(pos[:,0], pos[:,1], pos[:,2], event=ev)
+        pvr.show()
     """
-    pass
+
+    # ---------------------------------------------------------------------------
+    # Event-type constants
+    # ---------------------------------------------------------------------------
+    HOVER_START   = 'hover-start'
+    HOVER_END     = 'hover-end'
+    GRIP_DOWN     = 'gripdown'
+    GRIP_UP       = 'gripup'
+    TRIGGER_DOWN  = 'triggerdown'
+    TRIGGER_UP    = 'triggerup'
+
+    # Maps a "start" / "down" event to the matching "end" / "up" event used to
+    # dismiss annotations.
+    _RELEASE = {
+        'hover-start':  'hover-end',
+        'gripdown':     'gripup',
+        'triggerdown':  'triggerup',
+    }
+
+    def __init__(self):
+        self._bindings   = []   # list of (event_type, attribute, value)
+        self._annotation = None # (texts, trigger_event, color) or None
+
+    # ---------------------------------------------------------------------------
+    # Builder methods
+    # ---------------------------------------------------------------------------
+
+    def on(self, event_type, attribute, value):
+        """Register an A-Frame attribute change triggered by a controller event.
+
+        Parameters
+        ----------
+        event_type : str
+            A-Frame event name (use the class constants or a raw string).
+        attribute : str
+            A-Frame component/attribute to set, e.g. ``'material.color'``.
+        value : str
+            Value to assign, e.g. ``'#FF0'``.
+
+        Returns
+        -------
+        self
+            Supports method chaining.
+        """
+        self._bindings.append((event_type, attribute, value))
+        return self
+
+    def annotate(self, texts, trigger_event=None, color='#FFFFFF'):
+        """Show per-point text labels when a controller event fires.
+
+        Parameters
+        ----------
+        texts : str or sequence of str
+            Label text.  A single string is shared by every marker; a sequence
+            must match the number of data points.
+        trigger_event : str, optional
+            A-Frame event that reveals the label.  Defaults to
+            ``Event.TRIGGER_DOWN``.  The label is hidden on the corresponding
+            release event (e.g. ``triggerup`` for ``triggerdown``).
+        color : str
+            CSS color for the label text (default ``'#FFFFFF'``).
+
+        Returns
+        -------
+        self
+            Supports method chaining.
+        """
+        if trigger_event is None:
+            trigger_event = Event.TRIGGER_DOWN
+        self._annotation = (texts, trigger_event, color)
+        return self
+
+    # ---------------------------------------------------------------------------
+    # HTML-generation helpers (used by _artists.py)
+    # ---------------------------------------------------------------------------
+
+    def to_aframe_attrs(self):
+        """Return a dict of ``event-set__n`` HTML attributes for all bindings.
+
+        The returned dict can be unpacked directly into ``soup.new_tag()``.
+        """
+        attrs = {}
+        for i, (event_type, attribute, value) in enumerate(self._bindings):
+            attrs[f'event-set__{i}'] = f'_event: {event_type}; {attribute}: {value}'
+        return attrs
+
+    def make_annotation_tag(self, soup, text):
+        """Create an ``<a-text>`` child element for a single data point.
+
+        Parameters
+        ----------
+        soup : BeautifulSoup
+            The document to use for tag creation.
+        text : str
+            Label text for this specific point.
+
+        Returns
+        -------
+        bs4.element.Tag or None
+            The ``<a-text>`` element, or ``None`` if no annotation is set.
+        """
+        if self._annotation is None:
+            return None
+        _, trigger_event, color = self._annotation
+        release_event = Event._RELEASE.get(trigger_event, trigger_event + 'up')
+        tag = soup.new_tag('a-text',
+                           value=str(text),
+                           color=color,
+                           visible='false',
+                           position='0 0.08 0',
+                           align='center',
+                           scale='0.1 0.1 0.1')
+        tag['event-set__show'] = f'_event: {trigger_event}; visible: true'
+        tag['event-set__hide'] = f'_event: {release_event}; visible: false'
+        return tag
 

--- a/PlotVR/_plotvr.py
+++ b/PlotVR/_plotvr.py
@@ -19,9 +19,10 @@ DONE: added color (per-point), size (per-point), and marker type to scatterplot
 
 """
 
-__all__ = ['figure', 'scatter', 'show']
+__all__ = ['figure', 'scatter', 'show', 'Event']
 
 from ._artists import Scene
+from ._base import Event
 
 __all_scenes = {}
 __current_scene = None
@@ -46,13 +47,13 @@ def figure(num=None):
 
     return __current_scene
 
-def scatter(x, y, z, color="#FFFFFF", size=0.01, marker='sphere'):
+def scatter(x, y, z, color="#FFFFFF", size=0.01, marker='sphere', event=None):
     global __current_scene
 
     if __current_scene is None:
         figure()
     axes = __current_scene.gcf().gca()
-    axes.register_data(x, y, z, color, size, marker)
+    axes.register_data(x, y, z, color, size, marker, event)
 
 def show():
     global __current_scene, __all_scenes

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -63,7 +63,7 @@ class TestScatterFunction:
         x = np.array([0.0, 1.0])
         PlotVR.scatter(x, x, x)
         axes = PlotVR.figure(num=1).gcf().gca()
-        _, _, _, color, size, marker = axes._raw_data[0]
+        _, _, _, color, size, marker, _ = axes._raw_data[0]
         assert color == '#FFFFFF'
         assert size == 0.01
         assert marker == 'sphere'

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,320 @@
+"""Unit tests for VR controller Event handling (issue #7)."""
+import numpy as np
+import pytest
+
+import PlotVR as pvr
+from PlotVR._base import Event
+from PlotVR._artists import Scene, MarkerSet
+
+
+# ---------------------------------------------------------------------------
+# Event class – constants and construction
+# ---------------------------------------------------------------------------
+
+class TestEventConstants:
+    def test_hover_start_constant(self):
+        assert Event.HOVER_START == 'hover-start'
+
+    def test_hover_end_constant(self):
+        assert Event.HOVER_END == 'hover-end'
+
+    def test_grip_down_constant(self):
+        assert Event.GRIP_DOWN == 'gripdown'
+
+    def test_grip_up_constant(self):
+        assert Event.GRIP_UP == 'gripup'
+
+    def test_trigger_down_constant(self):
+        assert Event.TRIGGER_DOWN == 'triggerdown'
+
+    def test_trigger_up_constant(self):
+        assert Event.TRIGGER_UP == 'triggerup'
+
+    def test_starts_with_empty_bindings(self):
+        ev = Event()
+        assert ev._bindings == []
+
+    def test_starts_with_no_annotation(self):
+        ev = Event()
+        assert ev._annotation is None
+
+
+# ---------------------------------------------------------------------------
+# Event.on() – binding registration
+# ---------------------------------------------------------------------------
+
+class TestEventOn:
+    def test_on_returns_self_for_chaining(self):
+        ev = Event()
+        result = ev.on(Event.HOVER_START, 'material.color', '#FF0')
+        assert result is ev
+
+    def test_on_stores_binding(self):
+        ev = Event()
+        ev.on(Event.HOVER_START, 'material.color', '#FF0')
+        assert ev._bindings == [('hover-start', 'material.color', '#FF0')]
+
+    def test_multiple_bindings(self):
+        ev = Event()
+        ev.on(Event.HOVER_START, 'material.color', '#FF0')
+        ev.on(Event.HOVER_END,   'material.color', '#FFF')
+        assert len(ev._bindings) == 2
+
+    def test_chained_bindings(self):
+        ev = (Event()
+              .on(Event.GRIP_DOWN,    'material.color', '#F00')
+              .on(Event.GRIP_UP,      'material.color', '#FFF')
+              .on(Event.TRIGGER_DOWN, 'visible', 'false'))
+        assert len(ev._bindings) == 3
+
+
+# ---------------------------------------------------------------------------
+# Event.to_aframe_attrs()
+# ---------------------------------------------------------------------------
+
+class TestToAframeAttrs:
+    def test_empty_event_returns_empty_dict(self):
+        assert Event().to_aframe_attrs() == {}
+
+    def test_single_binding_key(self):
+        ev = Event().on(Event.HOVER_START, 'material.color', '#FF0')
+        attrs = ev.to_aframe_attrs()
+        assert 'event-set__0' in attrs
+
+    def test_single_binding_value_format(self):
+        ev = Event().on(Event.HOVER_START, 'material.color', '#FF0')
+        assert ev.to_aframe_attrs()['event-set__0'] == '_event: hover-start; material.color: #FF0'
+
+    def test_multiple_bindings_distinct_keys(self):
+        ev = (Event()
+              .on(Event.HOVER_START, 'material.color', '#FF0')
+              .on(Event.HOVER_END,   'material.color', '#FFF'))
+        attrs = ev.to_aframe_attrs()
+        assert 'event-set__0' in attrs
+        assert 'event-set__1' in attrs
+
+    def test_grip_down_binding(self):
+        ev = Event().on(Event.GRIP_DOWN, 'scale', '1.2 1.2 1.2')
+        assert ev.to_aframe_attrs()['event-set__0'] == '_event: gripdown; scale: 1.2 1.2 1.2'
+
+
+# ---------------------------------------------------------------------------
+# Event.annotate()
+# ---------------------------------------------------------------------------
+
+class TestEventAnnotate:
+    def test_annotate_returns_self(self):
+        ev = Event()
+        assert ev.annotate('hello') is ev
+
+    def test_annotate_stores_annotation(self):
+        ev = Event().annotate('label')
+        assert ev._annotation is not None
+
+    def test_annotate_stores_texts(self):
+        ev = Event().annotate('label')
+        texts, _, _ = ev._annotation
+        assert texts == 'label'
+
+    def test_annotate_default_trigger_is_triggerdown(self):
+        ev = Event().annotate('label')
+        _, trigger, _ = ev._annotation
+        assert trigger == Event.TRIGGER_DOWN
+
+    def test_annotate_custom_trigger(self):
+        ev = Event().annotate('label', trigger_event=Event.HOVER_START)
+        _, trigger, _ = ev._annotation
+        assert trigger == Event.HOVER_START
+
+    def test_annotate_default_color_is_white(self):
+        ev = Event().annotate('label')
+        _, _, color = ev._annotation
+        assert color == '#FFFFFF'
+
+    def test_annotate_custom_color(self):
+        ev = Event().annotate('label', color='#F00')
+        _, _, color = ev._annotation
+        assert color == '#F00'
+
+
+# ---------------------------------------------------------------------------
+# Event.make_annotation_tag()
+# ---------------------------------------------------------------------------
+
+class TestMakeAnnotationTag:
+    def _soup(self):
+        from bs4 import BeautifulSoup
+        return BeautifulSoup('<html></html>', features='html.parser')
+
+    def test_returns_none_when_no_annotation(self):
+        ev = Event()
+        assert ev.make_annotation_tag(self._soup(), 'x') is None
+
+    def test_returns_a_text_tag(self):
+        ev = Event().annotate('hello')
+        tag = ev.make_annotation_tag(self._soup(), 'hello')
+        assert tag.name == 'a-text'
+
+    def test_a_text_value(self):
+        ev = Event().annotate('my label')
+        tag = ev.make_annotation_tag(self._soup(), 'my label')
+        assert tag['value'] == 'my label'
+
+    def test_a_text_starts_invisible(self):
+        ev = Event().annotate('hello')
+        tag = ev.make_annotation_tag(self._soup(), 'hello')
+        assert tag['visible'] == 'false'
+
+    def test_a_text_has_show_event(self):
+        ev = Event().annotate('hello', trigger_event=Event.TRIGGER_DOWN)
+        tag = ev.make_annotation_tag(self._soup(), 'hello')
+        assert 'event-set__show' in tag.attrs
+        assert 'triggerdown' in tag['event-set__show']
+
+    def test_a_text_has_hide_event_on_release(self):
+        ev = Event().annotate('hello', trigger_event=Event.TRIGGER_DOWN)
+        tag = ev.make_annotation_tag(self._soup(), 'hello')
+        assert 'event-set__hide' in tag.attrs
+        assert 'triggerup' in tag['event-set__hide']
+
+    def test_hover_annotation_releases_on_hover_end(self):
+        ev = Event().annotate('hello', trigger_event=Event.HOVER_START)
+        tag = ev.make_annotation_tag(self._soup(), 'hello')
+        assert 'hover-end' in tag['event-set__hide']
+
+    def test_grip_annotation_releases_on_grip_up(self):
+        ev = Event().annotate('hello', trigger_event=Event.GRIP_DOWN)
+        tag = ev.make_annotation_tag(self._soup(), 'hello')
+        assert 'gripup' in tag['event-set__hide']
+
+    def test_a_text_color(self):
+        ev = Event().annotate('hello', color='#0F0')
+        tag = ev.make_annotation_tag(self._soup(), 'hello')
+        assert tag['color'] == '#0F0'
+
+
+# ---------------------------------------------------------------------------
+# MarkerSet integration
+# ---------------------------------------------------------------------------
+
+class TestMarkerSetWithEvent:
+    def _scene_and_markerset(self, x, y, z, **kwargs):
+        s = Scene()
+        axes = s.gcf().gca()
+        ms = MarkerSet(parent=axes, x=x, y=y, z=z, **kwargs)
+        return s, ms
+
+    def test_no_event_no_event_set_attrs(self):
+        x = np.array([0.0, 0.5])
+        s, _ = self._scene_and_markerset(x, x, x)
+        spheres = s.soup.find(id='markerset').find_all('a-sphere')
+        for sp in spheres:
+            assert not any(k.startswith('event-set__') for k in sp.attrs)
+
+    def test_event_adds_event_set_to_each_marker(self):
+        x = np.array([0.0, 0.5, 1.0])
+        ev = Event().on(Event.HOVER_START, 'material.color', '#FF0')
+        s, _ = self._scene_and_markerset(x, x, x, event=ev)
+        spheres = s.soup.find(id='markerset').find_all('a-sphere')
+        for sp in spheres:
+            assert 'event-set__0' in sp.attrs
+
+    def test_event_attr_value_correct(self):
+        x = np.array([0.5])
+        ev = Event().on(Event.HOVER_START, 'material.color', '#FF0')
+        s, _ = self._scene_and_markerset(x, x, x, event=ev)
+        sp = s.soup.find(id='markerset').find('a-sphere')
+        assert sp['event-set__0'] == '_event: hover-start; material.color: #FF0'
+
+    def test_multiple_bindings_all_present_on_markers(self):
+        x = np.array([0.0, 1.0])
+        ev = (Event()
+              .on(Event.HOVER_START, 'material.color', '#FF0')
+              .on(Event.HOVER_END,   'material.color', '#FFF'))
+        s, _ = self._scene_and_markerset(x, x, x, event=ev)
+        spheres = s.soup.find(id='markerset').find_all('a-sphere')
+        for sp in spheres:
+            assert 'event-set__0' in sp.attrs
+            assert 'event-set__1' in sp.attrs
+
+    def test_annotation_adds_a_text_child_to_each_marker(self):
+        x = np.array([0.0, 0.5])
+        labels = ['pt0', 'pt1']
+        ev = Event().annotate(labels)
+        s, _ = self._scene_and_markerset(x, x, x, event=ev)
+        spheres = s.soup.find(id='markerset').find_all('a-sphere')
+        for sp in spheres:
+            assert sp.find('a-text') is not None
+
+    def test_annotation_per_point_text(self):
+        x = np.array([0.0, 0.5, 1.0])
+        labels = ['alpha', 'beta', 'gamma']
+        ev = Event().annotate(labels)
+        s, _ = self._scene_and_markerset(x, x, x, event=ev)
+        spheres = s.soup.find(id='markerset').find_all('a-sphere')
+        for sp, expected in zip(spheres, labels):
+            assert sp.find('a-text')['value'] == expected
+
+    def test_annotation_single_string_broadcast(self):
+        x = np.array([0.0, 0.5, 1.0])
+        ev = Event().annotate('data point')
+        s, _ = self._scene_and_markerset(x, x, x, event=ev)
+        spheres = s.soup.find(id='markerset').find_all('a-sphere')
+        for sp in spheres:
+            assert sp.find('a-text')['value'] == 'data point'
+
+    def test_no_annotation_no_a_text(self):
+        x = np.array([0.0, 0.5])
+        ev = Event().on(Event.HOVER_START, 'material.color', '#FF0')
+        s, _ = self._scene_and_markerset(x, x, x, event=ev)
+        spheres = s.soup.find(id='markerset').find_all('a-sphere')
+        for sp in spheres:
+            assert sp.find('a-text') is None
+
+
+# ---------------------------------------------------------------------------
+# Scripting-layer integration
+# ---------------------------------------------------------------------------
+
+class TestScatterEventParam:
+    def test_scatter_accepts_event_kwarg(self):
+        x = np.array([0.0, 1.0])
+        ev = Event().on(Event.HOVER_START, 'material.color', '#FF0')
+        pvr.scatter(x, x, x, event=ev)  # must not raise
+
+    def test_scatter_stores_event_in_raw_data(self):
+        x = np.array([0.0, 1.0])
+        ev = Event().on(Event.HOVER_START, 'material.color', '#FF0')
+        pvr.scatter(x, x, x, event=ev)
+        axes = pvr.figure(num=1).gcf().gca()
+        stored_event = axes._raw_data[0][6]
+        assert stored_event is ev
+
+    def test_event_exported_from_package(self):
+        assert hasattr(pvr, 'Event')
+        assert pvr.Event is Event
+
+    def test_event_survives_show(self, tmp_path, monkeypatch):
+        from unittest.mock import patch
+        monkeypatch.chdir(tmp_path)
+        with patch('PlotVR._artists.display'):
+            x = np.array([0.0, 0.5, 1.0])
+            ev = Event().on(Event.HOVER_START, 'material.color', '#FF0')
+            pvr.scatter(x, x, x, event=ev)
+            pvr.show()
+        html = (tmp_path / 'PlotVR_Figure 1.html').read_text()
+        assert 'event-set__0' in html
+        assert 'hover-start' in html
+
+    def test_annotation_in_html_after_show(self, tmp_path, monkeypatch):
+        from unittest.mock import patch
+        monkeypatch.chdir(tmp_path)
+        with patch('PlotVR._artists.display'):
+            x = np.array([0.0, 1.0])
+            ev = Event().annotate(['pt0', 'pt1'])
+            pvr.scatter(x, x, x, event=ev)
+            pvr.show()
+        html = (tmp_path / 'PlotVR_Figure 1.html').read_text()
+        assert 'a-text' in html
+        assert 'pt0' in html
+        assert 'pt1' in html


### PR DESCRIPTION
Adds a fully-implemented `Event` class to `_base.py` that maps A-Frame
controller events (hover, grip, trigger) to marker attribute changes and
per-point text annotations.  Handlers are translated to A-Frame
`event-set__` attributes and `<a-text>` child elements at HTML render time.

- `Event.on(event_type, attribute, value)` – register any attribute change
- `Event.annotate(texts, trigger_event, color)` – per-point label on trigger
- Event type constants: HOVER_START/END, GRIP_DOWN/UP, TRIGGER_DOWN/UP
- `MarkerSet` and `Axes.register_data` accept an optional `event` kwarg
- `pvr.scatter(..., event=ev)` exposes the feature at the scripting layer
- `Event` exported from the top-level `PlotVR` package
- 46 new tests in `tests/test_events.py`; all 100 tests pass

https://claude.ai/code/session_01CHT3vKoPMGwmoHGmKxiLDi